### PR TITLE
SearchSortFactory  documentation corrections

### DIFF
--- a/engine/src/main/java/org/hibernate/search/engine/search/sort/dsl/SearchSortFactory.java
+++ b/engine/src/main/java/org/hibernate/search/engine/search/sort/dsl/SearchSortFactory.java
@@ -93,11 +93,11 @@ public interface SearchSortFactory {
 	 * This is mainly useful to mix imperative and declarative style when building sorts, e.g.:
 	 * <pre>{@code
 	 * f.composite( c -> {
-	 *    c.add( f.byField( "category" ) );
+	 *    c.add( f.field( "category" ) );
 	 *    if ( someInput != null ) {
-	 *        c.add( f.byDistance( "location", someInput.getLatitude(), someInput.getLongitude() );
+	 *        c.add( f.distance( "location", someInput.getLatitude(), someInput.getLongitude() );
 	 *    }
-	 *    c.add( f.byIndexOrder() );
+	 *    c.add( f.indexOrder() );
 	 * } )
 	 * }</pre>
 	 *


### PR DESCRIPTION
removed the use of the deprecated byField and byDistance functions from the SearchSortFactory